### PR TITLE
Fix Packaging Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,36 @@ After copying over those folders, make sure to duplicate the `vc170` folders as 
 
 Yay! Now we are done with integrating wwise!
 
+### Changing build tools from VS 2019 to VS 2022
+In Unreal Engine 5.1, by default, Visual Studio 2019 build tools will be used if they are installed. 
+
+> [!IMPORTANT]
+> The below changes should only be made if Visual Studio 2019 is installed alongside Visual Studio 2022.
+
+To change this, navigate to `%APPDATA%\Unreal Engine\UnrealBuildTool` and open `BuildConfiguration.xml` with your favorite XML editor.
+
+Your initial configuration will look like below:
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
+</Configuration>
+```
+
+Update the configuration to look like this:
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
+    <VCProjectFileGenerator>
+        <Version>VisualStudio2022</Version>
+    </VCProjectFileGenerator>
+    <WindowsPlatform>
+        <Compiler>VisualStudio2022</Compiler>
+    </WindowsPlatform>
+</Configuration>
+```
+
+Congratulations on making it through the configuration!
+
 ## Launching
 
 After doing all of those steps, we are ready! Double click the `Pal.uproject` file and it should open in Unreal Engine!
@@ -135,6 +165,9 @@ After doing all of those steps, we are ready! Double click the `Pal.uproject` fi
 
 > [!IMPORTANT]
 > If the file doesn't open in unreal engine and instead asks you for associations, open Unreal Engine, and open the file from there instead
+
+> [!NOTE]
+> You may see a popup on launch about Wwise project path issues, ignore it and press the X in the corner to close the popup.
 
 
 ## Help

--- a/Source/Pal/Private/PalModule.cpp
+++ b/Source/Pal/Private/PalModule.cpp
@@ -1,3 +1,3 @@
 #include "Modules/ModuleManager.h"
 
-// IMPLEMENT_MODULE(FDefaultGameModuleImpl, Pal);
+IMPLEMENT_PRIMARY_GAME_MODULE(FDefaultGameModuleImpl, Pal, Pal);


### PR DESCRIPTION
Currently while packaging the release it will fail complaining of not having external symbols.

Example:
```
UATHelper: Packaging (Windows): Module.Launch.cpp.obj : error LNK2019: unresolved external symbol "bool GIsGameAgnosticExe" (?GIsGameAgnosticExe@@3_NA) referenced in function "void __cdecl LaunchFixGameNameCase(void)" (?LaunchFixGameNameCase@@YAXXZ)
UATHelper: Packaging (Windows): Module.Core.9_of_20.cpp.obj : error LNK2001: unresolved external symbol "bool GIsGameAgnosticExe" (?GIsGameAgnosticExe@@3_NA)
UATHelper: Packaging (Windows): Module.AutomationWorker.cpp.obj : error LNK2001: unresolved external symbol "wchar_t * GInternalProjectName" (?GInternalProjectName@@3PA_WA)
```

This fix resolves these by implementing the primary game module on Pal module instead of commenting it out like it is currently.

There has also been documentation added to resolve probably unintended building with VS 2019 build tools.

This fix has been tested by:

* Following readme to a point.
* Building the project in VS after generating solution files first from the uproject.
* Opening the editor.
* Packaging for shipping.