### PR TITLE
Add the ModdingEx Plugin as a Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Plugins/ModdingEx"]
+	path = Plugins/ModdingEx
+	url = git@github.com:ToniMacaroni/ModdingEx.git


### PR DESCRIPTION
This PR adds the ModdingEx utility plugin (at version 1.1.0) as a submodule to the included plugins.

Being a submodule this also means the plugin will **only** be included if users clone the repo via git (with the `--recursive` flag or doing a `submodule update --init` directly afterwards)