### PR TITLE
Allow writing newlines within localization Text fields

### DIFF
--- a/Source/Pal/Public/PalLocalizedTextData.h
+++ b/Source/Pal/Public/PalLocalizedTextData.h
@@ -7,7 +7,7 @@ USTRUCT(BlueprintType)
 struct FPalLocalizedTextData : public FTableRowBase {
     GENERATED_BODY()
 public:
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, meta=(AllowPrivateAccess=true))
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, meta=(AllowPrivateAccess=true, MultiLine=true))
     FText TextData;
     
     PAL_API FPalLocalizedTextData();


### PR DESCRIPTION
Existing rows in localization Data Tables contain newline characters, but you couldn't add more in UE.